### PR TITLE
Clean empty files in Targeted gathering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM quay.io/openshift/origin-must-gather:4.7 as builder
 FROM registry.access.redhat.com/ubi8-minimal:latest
 RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
 
-RUN microdnf -y install rsync tar gzip graphviz jq
+RUN microdnf -y install rsync tar gzip graphviz jq findutils
 
 COPY --from=gobuilder /go/bin/pprof /usr/bin/pprof
 COPY --from=builder /usr/bin/oc /usr/bin/oc

--- a/collection-scripts/targeted
+++ b/collection-scripts/targeted
@@ -21,6 +21,11 @@ for localns in $(/usr/bin/oc get forkliftcontrollers.forklift.konveyor.io --all-
   /usr/bin/targeted_logs ${localns}
 done
 
+# Remove empty files to ensure that the directory structure doesn't confuse user with not relevant entries
+echo "Cleaning must-gather directory structure..."
+find /must-gather -type f -empty -print -delete
+find /must-gather -type d -empty -print -delete
+
 # Tar all must-gather artifacts for faster transmission 
 echo "Tarring must-gather artifacts..."
 archive_path="/must-gather-archive"


### PR DESCRIPTION
As a result of targeted gathering's log files filtering, there could be empty files (log files with no content related to the targeted object gathering).

Adding cleanup using find, which deletes these files and dirs before downloading must-gather result from cluster.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1994978