### PR TITLE
Fix the gathering of importer and populator pods logs

### DIFF
--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -55,10 +55,6 @@ if [ ! -z $PLAN ]; then
     plan_resources+=("$PLAN")
     vm_resources+=($(echo $plan_data | jq -r '.status.migration.vms[] .name'))
     target_ns=$(echo $plan_data | jq -r '.spec.targetNamespace')
-    migration_ids=$(echo $plan_data | jq -r '.status.migration.history[].migration .uid')
-    log_filter_query="$log_filter_query|$migration_ids"
-    # Store the migration id to allow populator pod logs gathering
-    echo "${migration_ids}" >> /tmp/migrations
   fi
 fi
 
@@ -134,6 +130,11 @@ if [ ! -z "${vm_resources}" ]; then
         log_filter_query="$log_filter_query|$target_vm_name"
         dump_resource "virtualmachine" $target_vm_name $target_ns
         present_vm_resources+=("$target_vm_name")
+
+        migration_id=($(echo $vm_data | jq -r '.metadata.labels.migration'))
+        log_filter_query="$log_filter_query|$migration_id"
+        # Store the migration id to allow populator pod logs gathering
+        echo ${migration_id} >> /tmp/migrations
 
         # Gather VM hook jobs if present
         for job_name in $(/usr/bin/oc get jobs --no-headers -n $MIGRATION_NS --selector vmID=$target_vm_id -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}'); do

--- a/collection-scripts/targeted_logs
+++ b/collection-scripts/targeted_logs
@@ -16,6 +16,7 @@ namespaces=$1
 targeted_query="$(cat /tmp/targeted_logs_grep_query)"
 target_vms="$(touch /tmp/target_vms; cat /tmp/target_vms)"
 target_dvs="$(touch /tmp/dvs; cat /tmp/dvs)"
+target_pvcs="$(touch /tmp/pvcs; cat /tmp/pvcs)"
 target_job_pods="$(touch /tmp/job_pods; cat /tmp/job_pods)"
 target_migrations="$(touch /tmp/migrations; cat /tmp/migrations)"
 
@@ -84,7 +85,7 @@ for nsvm in ${target_vms[@]}; do
 done
 
 # Collect CDI/importer pod logs for imported DVs
-for nsdv in ${target_dvs[@]}; do
+for nsdv in ${target_dvs[@]} ${target_pvcs[@]}; do
   IFS="," read ns dv <<< $nsdv
   pod=$(oc get pods --no-headers -n $ns --selector cdi.kubevirt.io=importer -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | grep $dv | head -1)
 

--- a/collection-scripts/targeted_logs
+++ b/collection-scripts/targeted_logs
@@ -85,12 +85,34 @@ for nsvm in ${target_vms[@]}; do
 done
 
 # Collect CDI/importer pod logs for imported DVs
-for nsdv in ${target_dvs[@]} ${target_pvcs[@]}; do
+for nsdv in ${target_dvs[@]}; do
   IFS="," read ns dv <<< $nsdv
   pod=$(oc get pods --no-headers -n $ns --selector cdi.kubevirt.io=importer -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | grep $dv | head -1)
 
   if [[ -z $pod ]]; then
     echo "Importer Pod for $nsdv doesn't exist, skipping."
+  else
+    object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
+    mkdir -p ${object_collection_path}
+    echo "[ns=${ns}][pod=${pod}] Collecting CDI Importer Pod logs..."
+    /usr/bin/oc logs --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
+    pwait $max_parallelism
+  fi
+done
+
+# Collect CDI/importer pod logs for imported PVCs
+for nspvc in ${target_pvcs[@]}; do
+  IFS="," read ns pvc <<< $nspvc
+
+  pvc_yaml=$(cat "/must-gather/namespaces/${ns}/crs/persistentvolumeclaim/${pvc}.yaml")
+  has_cdi=$(echo $pvc_yaml | grep "app: containerized-data-importer")
+  if [[ -z $has_cdi ]]; then
+    continue
+  fi
+
+  pod=$(oc get pods --no-headers -n $ns --selector cdi.kubevirt.io=importer -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | grep $pvc | head -1)
+  if [[ -z $pod ]]; then
+    echo "Importer Pod for $nspvc doesn't exist, skipping."
   else
     object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
     mkdir -p ${object_collection_path}


### PR DESCRIPTION
Since we moved to post the VM in the last phase, the VM now usually
contains PVC in the volume spec instead of DV. We need to look on both
in order to gather the relevant data.
Also, adding migrations IDs based on the VM label. This will allow us to
gather the populator pod logs when there is no plan ID provided.
