### PR TITLE
Add warm migration resources

### DIFF
--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -119,11 +119,18 @@ if [ ! -z "${vm_resources}" ]; then
 
         # Gather VMs PersistentVolumeClaims
         for pvc_name in $(echo $vm_data | jq -r '.spec.template.spec.volumes[] .persistentVolumeClaim.claimName'); do
-          log_filter_query="$log_filter_query|$pvc_name"
-          dump_resource "persistentvolumeclaim" $pvc_name $target_ns
+          # In order to gather the scratch PVCs in warm migrations
+          for pvc in $(/usr/bin/oc get pvc -n ${target_ns} -o json | jq -c '.items | .[]'); do
+            if [ $(echo $pvc | jq -r '.spec.volumeName') != $pvc_name ]; then
+              continue
+            fi
+            name=$(echo $pvc | jq -r 'metadata.name')
+            log_filter_query="$log_filter_query|name"
+            dump_resource "persistentvolumeclaim" name $target_ns
 
-          # Store PVC in list to allow populator pod logs gathering
-          echo "${target_ns},${pvc_name}" >> /tmp/pvcs
+            # Store PVC in list to allow populator pod logs gathering
+            echo "${target_ns},${name}" >> /tmp/pvcs
+          done
         done
 
         target_vm_id=($(echo $vm_data | jq -r '.metadata.labels.vmID'))

--- a/collection-scripts/targeted_logs
+++ b/collection-scripts/targeted_logs
@@ -110,15 +110,17 @@ for nspvc in ${target_pvcs[@]}; do
     continue
   fi
 
-  pod=$(oc get pods --no-headers -n $ns --selector cdi.kubevirt.io=importer -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | grep $pvc | head -1)
-  if [[ -z $pod ]]; then
+  pods=$(oc get pods --no-headers -n $ns --selector cdi.kubevirt.io=importer -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | grep $pvc)
+  if [[ -z $pods ]]; then
     echo "Importer Pod for $nspvc doesn't exist, skipping."
   else
-    object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
-    mkdir -p ${object_collection_path}
-    echo "[ns=${ns}][pod=${pod}] Collecting CDI Importer Pod logs..."
-    /usr/bin/oc logs --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
-    pwait $max_parallelism
+    for pod in ${pods[@]}; do
+      object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
+      mkdir -p ${object_collection_path}
+      echo "[ns=${ns}][pod=${pod}] Collecting CDI Importer Pod logs..."
+      /usr/bin/oc logs --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
+      pwait $max_parallelism
+    done
   fi
 done
 


### PR DESCRIPTION
When importing using CDI in warm migrations we may have multiple PVCs (scratch) and multiple importer pods to the migration. This patch adds the logs of these relevant resources.