### PR TITLE
Enable hermetic build for forklift-must-gather

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 must-gather**
+.vscode/

--- a/.tekton/forklift-must-gather-pull-request.yaml
+++ b/.tekton/forklift-must-gather-pull-request.yaml
@@ -27,11 +27,13 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: Dockerfile
+    value: Dockerfile-downstream
   - name: path-context
     value: .
   - name: build-source-image
     value: "true"
+  - name: prefetch-input
+    value: '[{"type": "rpm", "path": "."}]'
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -76,7 +78,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -174,6 +176,10 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: dev-package-managers
+        value: "true"
+      - name: ACTIVATION_KEY
+        value: activation-key-rhel8
       runAfter:
       - clone-repository
       taskRef:

--- a/.tekton/forklift-must-gather-push.yaml
+++ b/.tekton/forklift-must-gather-push.yaml
@@ -26,11 +26,13 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator/forklift-must-gather:{{revision}}
   - name: dockerfile
-    value: Dockerfile
+    value: Dockerfile-downstream
   - name: path-context
     value: .
   - name: build-source-image
     value: "true"
+  - name: prefetch-input
+    value: '[{"type": "rpm", "path": "."}]'
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -75,7 +77,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -173,6 +175,10 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: dev-package-managers
+        value: "true"
+      - name: ACTIVATION_KEY
+        value: activation-key-rhel8
       runAfter:
       - clone-repository
       taskRef:

--- a/Dockerfile-downstream
+++ b/Dockerfile-downstream
@@ -1,0 +1,24 @@
+FROM registry.redhat.io/openshift4/ose-cli:v4.15.0-202503170806.p0.g8231637.assembly.stream.el8
+
+ARG VERSION="2.9.0"
+
+WORKDIR /app
+COPY --chown=1001:0 ./ ./
+
+RUN dnf -y update --nobest && dnf clean all
+RUN dnf install -y findutils graphviz jq rsync tar && dnf clean all
+
+COPY collection-scripts/* /usr/bin/
+
+ENTRYPOINT ["/usr/bin/gather"]
+
+LABEL \
+    com.redhat.component="mtv-must-gather-container" \
+    version="$VERSION" \
+    name="migration-toolkit-virtualization/mtv-must-gather-rhel8" \
+    license="Apache License 2.0" \
+    io.k8s.display-name="Migration Toolkit for Virtualization" \
+    io.k8s.description="Migration Toolkit for Virtualization - Must Gather" \
+    io.openshift.tags="migration,mtv,forklift" \
+    summary="Migration Toolkit for Virtualization - Must Gather" \
+    maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>"

--- a/redhat.repo
+++ b/redhat.repo
@@ -1,0 +1,17720 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+
+[satellite-utils-6.15-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.3 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[custom-metrics-autoscaler-2-for-rhel-8-$basearch-rpms]
+name = Custom Metrics Autoscaler 2 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/custom-metrics-autoscaler/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoai-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift AI 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoai/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Extended Update Support (RPMS)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-devtools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16 Developer Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-devtools/16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.13-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.13 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.13-rpms]
+name = Red Hat Container Development Kit 3.13 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-4.10-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability 4.10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMS)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.9-rpms]
+name = Red Hat Container Development Kit 3.9 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-4-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.6 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.16-rpms]
+name = Red Hat Container Development Kit 3.16 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoar-nodejs-12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Application Runtimes Node.js v12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoar-nodejs/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-for-rhel-8-$basearch-textonly-rpms]
+name = Red Hat Ceph Storage 6 Text-Only Advisories for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-textonly/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-far/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.11-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-8-$basearch-source-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/network-observability/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.13-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.13 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2.0-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 2.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-hub-4-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Automation Hub 4 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/automation-hub/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch (Source RPMS)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-capsule/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-2.2-for-rhel-8-$basearch-rpms]
+name = Red Hat build of Quarkus 2.2 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/2.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-rt-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Real Time (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.5-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.14 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-mgmt-agent-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization 4 Management Agents Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-mgmt-agent/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.1-for-rhel-8-$basearch-rpms]
+name = OpenShift Pipelines 1.1 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-debug-rpms]
+name = Red Hat Container Development Kit 3.4 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.9-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.9 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.7-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-8-$basearch-source-rpms]
+name = Fast Datapath for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/fast-datapath/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.8-for-rhel-8-$basearch-rpms]
+name = Red Hat Directory Server 11.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-capsule/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Engine 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/openstack/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Migration Toolkit 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosdt-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift distributed tracing 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosdt/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Science 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-3.62-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 3.62 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/3.62/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-deployment-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16 Director Deployment Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cfme-5.11-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat CloudForms Management Engine 5.11 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/cfme/5.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-source-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-snr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhui-4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Update Infrastructure 4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhui/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/satellite/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.3-for-rhel-8-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.3 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-mgmt-agent-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization 4 Management Agents for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-mgmt-agent/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-aus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-source-rpms]
+name = Red Hat Container Development Kit 3.4 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-8-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.3-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-far/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.11-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-eus-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-beta-for-rhel-8-s390x-source-rpms]
+name = Fast Datapath Beta for RHEL 8 IBM z Systems (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/s390x/fast-datapath/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-serverless-1-for-rhel-8-$basearch-rpms]
+name = Red Hat Openshift Serverless 1 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoss/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Ansible Engine 2 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoai-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift AI 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoai/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.1-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Pipelines 1.1 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Certification for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cert/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cfme-5.11-for-rhel-8-$basearch-rpms]
+name = Red Hat CloudForms Management Engine for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cfme/5.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.5-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-for-rhel-8-$basearch-eus-debug-rpms]
+name = Advanced Virtualization for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/advanced-virt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-ocs-4.6-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat OpenShift Container Storage 4.6 Server EUS (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocs-server/4.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-tools-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat OpenStack Platform 15 Tools for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/openstack-tools/15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Tools Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-tools/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/openstack-deployment-tools/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-8-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/appstream/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[satellite-tools-6.8-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[devworkspace-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Devworkspace 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/devworkspace/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-rt-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Real Time (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/rt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-hub-4.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Automation Hub 4.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/automation-hub/4.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-debug-rpms]
+name = Red Hat Container Development Kit 2.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.11-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.11 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-for-rhel-8-$basearch-eus-rpms]
+name = Advanced Virtualization for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/advanced-virt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cluster-observability-operator-1-for-rhel-8-$basearch-textonly-rpms]
+name = Cluster Observability Operator (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cluster-observability-operator/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jon-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Operations Network Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jon/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-for-rhel-8-$basearch-eus-source-rpms]
+name = Advanced Virtualization for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/advanced-virt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[devworkspace-0.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Devworkspace 0.10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/devworkspace/0.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.13-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.13 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-crb-for-rhel-8-$basearch-source-rpms]
+name = Advanced Virtualization CodeReady Builder for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/advanced-virt-crb/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-2.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat build of Quarkus 2.2 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/2.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[interconnect-2-for-rhel-8-$basearch-source-rpms]
+name = JBoss Interconnect 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/interconnect/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-stf/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.4-for-rhel-8-$basearch-rhui-source-rpms]
+name = Single Sign-On 7.4 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rh-sso/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-8-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-2.9-for-rhel-8-$basearch-rpms]
+name = Red Hat AMQ Clients 2.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/2.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-hub-4-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Automation Hub 4 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/automation-hub/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[mirror-registry-2-for-rhel-8-$basearch-debug-rpms]
+name = mirror registry for Red Hat OpenShift for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/mirror-registry/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-mon-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage MON 4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-mon/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhvh-4-build-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization Host Build for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhvh-build/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-8-$basearch-rpms]
+name = Kernel Module Management 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/kmm/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.10-rpms]
+name = Red Hat Container Development Kit 3.10 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.11-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4.4-manager-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization Manager 4.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-manager/4.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-2.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Jaeger 2.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/2.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Certificate System 10.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.4-for-rhel-8-$basearch-rhui-rpms]
+name = Single Sign-On 7.4 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rh-sso/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.5-for-rhel-8-$basearch-debug-rpms]
+name = Single Sign-On 7.5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-1-for-rhel-8-$basearch-debug-rpms]
+name = JBoss AMQ Interconnect 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq-interconnect/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-crb-beta-for-rhel-8-$basearch-rpms]
+name = Advanced Virtualization CodeReady Builder Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/advanced-virt-crb/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.6 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-stf/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.13-for-rhel-8-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-8-$basearch-debug-rpms]
+name = Kernel Module Management 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/kmm/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.8 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-source-rpms]
+name = Red Hat Container Development Kit 3.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/certsys/10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.4-for-rhel-8-$basearch-rpms]
+name = Single Sign-On 7.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Migration Toolkit 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.7-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.7 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-2-for-rhel-8-$basearch-rpms]
+name = Red Hat build of Quarkus 2 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-aus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.7-for-rhel-8-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cert-manager/1.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-8-$basearch-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMS)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.9 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-crb-beta-for-rhel-8-$basearch-source-rpms]
+name = Advanced Virtualization CodeReady Builder Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/advanced-virt-crb/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-services-catalog-1-tech-preview-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Automation Services Catalog 1 Tech Preview for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/automation-services-catalog-tech-preview/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Server Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jws/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-manager-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization Manager 4 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-manager/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.8 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-tools/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-1-for-rhel-8-$basearch-rhui-debug-rpms]
+name = JBoss Core Services (RHEL 8) (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/jbcs/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[source-to-image-1-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Source-to-Image 1 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/source-to-image/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-crb-beta-for-rhel-8-$basearch-debug-rpms]
+name = Advanced Virtualization CodeReady Builder Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/advanced-virt-crb/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-devtools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16 Developer Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-devtools/16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-cinderlib-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16.2 Cinderlib for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-8-$basearch-debug-rpms]
+name = Single Sign-On 7.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.3-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-cinderlib-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16.1 Cinderlib for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat Migration Toolkit 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-osd-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage OSD 4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-osd/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.8-rpms]
+name = Red Hat Container Development Kit 3.8 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jpp-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Portal Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jpp/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat AMQ Clients 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-8-$basearch-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel8/$basearch/openjdk/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.13-for-rhel-8-$basearch-rpms]
+name = Logical Volume Manager Storage 4.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 15 Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-devtools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 15 Developer Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-devtools/15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-nfv-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Real Time for NFV (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-e4s-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-stf/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1-for-rhel-8-$basearch-textonly-rpms]
+name = Red Hat OpenShift Builds for RHEL 8 $basearch Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-1-for-rhel-8-$basearch-rpms]
+name = Red Hat build of Quarkus 1 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.3-for-rhel-8-$basearch-rpms]
+name = Single Sign-On 7.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.8-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Engine 2.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.8-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.8 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-utils/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Migration Toolkit 1.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-mgmt-agent-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Management Agents for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-mgmt-agent/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-e4s-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.0-early-access-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.0 Early Access for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-0-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Extended Update Support (Source RPMS)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Builds for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosdt-3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift distributed tracing 3 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosdt/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Engine 2.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.7-rpms]
+name = Red Hat Container Development Kit 3.7 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.5-for-rhel-8-$basearch-source-rpms]
+name = Single Sign-On 7.5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-8-$basearch-source-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 8 for Red Hat OpenShift (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/osso/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-8-$basearch-rpms]
+name = JBoss Web Server 6 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jws/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-8-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.6-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.6 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.10-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosdt-2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift distributed tracing 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosdt/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-tools-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat OpenStack Platform 16 Tools for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/openstack-tools/16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cfme-5.11-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat CloudForms Management Engine 5.11 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/cfme/5.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.12 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.17-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.17 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-cinderlib-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16.2 Cinderlib for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Builds 1.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.12-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.12 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.8-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.8 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat JBoss Data Grid 8.1 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/8.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-mgmt-agent-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Management Agents Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-mgmt-agent/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.16 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.7-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.7 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.6-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1.20-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Data Science 1.20 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Builds 1.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Certificate System 10.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Engine 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.13-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Engine 2.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-8-$basearch-rpms]
+name = JBoss Web Server 5 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jws/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.24-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Jaeger 1.24 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.24/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-8-$basearch-debug-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 8 for Red Hat OpenShift (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/osso/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-8-$basearch-source-rpms]
+name = JBoss Web Server 6 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jws/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/certsys/10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-8-$basearch-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel8/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1.0-for-rhel-8-$basearch-source-rpms]
+name = Kernel Module Management 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/kmm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-3-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Ansible Engine 2 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhui-4-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Update Infrastructure 4 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhui/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-aus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.8-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Ansible Engine 2.8 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-8-$basearch-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.3-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Single Sign-On 7.3 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rh-sso/7.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-8-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/8.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/certsys/10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Directory Server 11.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.4-for-rhel-8-$basearch-rpms]
+name = Red Hat Certificate System 10.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-2.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat AMQ Clients 2.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/2.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.2-for-rhel-8-$basearch-rpms]
+name = Red Hat Migration Toolkit 1.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.0-early-access-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.0 Early Access for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoss-1.29-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Openshift Serverless 1.29 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoss/1.29/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-8-$basearch-rpms]
+name = Red Hat Application Interconnect for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhai/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.6-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-cinderlib-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16 Cinderlib for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/openstack/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/satellite/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-serverless-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Openshift Serverless 1 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoss/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-8-$basearch-debug-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rodoo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-cinderlib-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16 Cinderlib for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-1-for-rhel-8-$basearch-rhui-rpms]
+name = JBoss Core Services (RHEL 8) (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/jbcs/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-3.62-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 3.62 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/3.62/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.11-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.11 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-services-catalog-1-tech-preview-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Automation Services Catalog 1 Tech Preview for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/automation-services-catalog-tech-preview/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.12-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-manager-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization Manager 4 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-manager/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-utils/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[devworkspace-0.10-for-rhel-8-$basearch-rpms]
+name = Red Hat Devworkspace 0.10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/devworkspace/0.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.10-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.10 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-rpms]
+name = Red Hat Container Development Kit 3.5 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-services-catalog-1-tech-preview-for-rhel-8-$basearch-rpms]
+name = Red Hat Automation Services Catalog 1 Tech Preview for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/automation-services-catalog-tech-preview/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat build of Quarkus 3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.14-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.14 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Certification for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cert/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.4-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Tools and Services 4.4 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-8-$basearch-rhui-debug-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 8) (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/jbeap/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Discovery 0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery/0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.11-for-rhel-8-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-eus-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.1-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Pipelines 1.1 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosdt-3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift distributed tracing 3 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosdt/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat build of Quarkus 2 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.3-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.14-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-textonly-1-for-middleware-rpms]
+name = Red Hat build of Quarkus Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/quarkus/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.7-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-client-for-rhel-8-$basearch-rpms]
+name = Red Hat Storage Native Client for RHEL 8 (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-client/3.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.13-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.3-for-rhel-8-$basearch-rhui-rpms]
+name = Single Sign-On 7.3 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rh-sso/7.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-8-$basearch-rpms]
+name = Single Sign-On 7.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.2-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.2 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 8 $basearch from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rhceph-tools/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16 Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.3-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Tools and Services 4.3 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss AMQ Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.14-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.6-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.6 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Quay 3.11 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quay/3.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-manager-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization Manager 4 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-osd-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage OSD 4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-osd/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.5-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/8.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-mon-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage MON 4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-mon/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-2.0-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Jaeger 2.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/2.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.14-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.14 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.7-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Directory Server 11.7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-deployment-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 15 Director Deployment Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-3.62-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 3.62 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/3.62/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-for-rhel-8-$basearch-rpms]
+name = Advanced Virtualization for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/advanced-virt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-aus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 2.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-nmo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-deployment-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16 Director Deployment Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.5-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.9-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Engine 2.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-8-$basearch-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rodoo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 8 $basearch from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rhceph-tools/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-e4s-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Certificate System 10.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-tus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Grid Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jb-datagrid/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-8-$basearch-rpms]
+name = Red Hat Certification for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cert/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.17-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Jaeger 1.17 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhvh-4-build-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization Host Build for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhvh-build/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/dirsrv/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 8 $basearch from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rhceph-tools/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Migration Toolkit 1.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.10 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat AMQ Clients 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Service Interconnect for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.2 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[3scale-amp-2-rpms-for-rhel-8-$basearch-rpms]
+name = Red Hat 3scale API Management Platform 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/3scale-amp/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosdt-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift distributed tracing 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosdt/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.3-for-rhel-8-$basearch-rpms]
+name = Red Hat Certificate System 10.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.0-for-rhel-8-$basearch-rpms]
+name = OpenShift Pipelines 1.0 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/baseos/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[rhacm-2.14-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.2-for-rhel-8-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.2 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.6-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.6 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.5-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.5 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/satellite/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-services-catalog-1-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Automation Services Catalog 1 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/automation-services-catalog/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-beta-for-rhel-8-$basearch-source-rpms]
+name = Fast Datapath Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/fast-datapath/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.13-for-rhel-8-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-tus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-deployment-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16.2 Director Deployment Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.12-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.12 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-1.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 1.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.9-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.9 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-ember-0.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Ember-CSI 0.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-ember/0.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhui-4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Update Infrastructure 4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhui/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.6-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.6 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.22-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Jaeger 1.22.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.22/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.8-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Web Server 6 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jws/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-tools/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-rpms]
+name = Red Hat Container Development Kit 3.4 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-aus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-4.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability 4.10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa/4.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.10-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Builds 1.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-nfs-for-rhel-8-$basearch-rpms]
+name = Red Hat Gluster Storage 3 NFS for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server-nfs/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-serverless-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Openshift Serverless 1 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoss/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Certificate System 10.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-crb-for-rhel-8-$basearch-debug-rpms]
+name = Advanced Virtualization CodeReady Builder for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/advanced-virt-crb/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.3-for-rhel-8-$basearch-rpms]
+name = OpenShift Tools and Services 4.3 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-ocs-4-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Storage 4 Server (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocs-server/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.11-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Data Foundation (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhodf/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.2 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.9-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Ansible Engine 2.9 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.15-rpms]
+name = Red Hat Container Development Kit 3.15 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Engine 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhvh-4-build-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization Host Build for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhvh-build/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[devworkspace-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Devworkspace 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/devworkspace/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[wfk-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Framework Kit Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/wfk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.8-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Ansible Engine 2.8 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.13-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-0-for-rhel-8-$basearch-rpms]
+name = Red Hat Discovery 0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery/0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-mdr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmtc-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Migration Toolkit for Containers for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmtc/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.7-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-8-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-ocs-4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Storage 4 Server (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocs-server/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.15-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.14-rpms]
+name = Red Hat Container Development Kit 3.14 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-maintenance/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-beta-for-rhel-8-s390x-debug-rpms]
+name = Fast Datapath Beta for RHEL 8 IBM z Systems (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/s390x/fast-datapath/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openliberty-textonly-1-for-middleware-rpms]
+name = Open Liberty Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openliberty/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Migration Toolkit 1.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.11-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.11 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-services-catalog-1-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Automation Services Catalog 1 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/automation-services-catalog/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-hub-4.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Automation Hub 4.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/automation-hub/4.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/openstack-deployment-tools/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-8-$basearch-debug-rpms]
+name = Fast Datapath for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/fast-datapath/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-nhc/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMS)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.0-early-access-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.0 Early Access for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-tools/4/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.5-for-rhel-8-$basearch-rpms]
+name = Single Sign-On 7.5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-8-$basearch-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/network-observability/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-cinderlib-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16.1 Cinderlib for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Certificate System 10.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/dirsrv/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.16 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-source-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.12-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-stf/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.10-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.14-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.9-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-eus-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Update Services SAP Solutions (RPMS)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat JBoss Data Grid 8.1 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/8.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-tools-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat OpenStack Platform 15 Tools for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/openstack-tools/15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.14 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.4 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-tools-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat OpenStack Platform 16 Tools for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/openstack-tools/16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-mgmt-agent-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Management Agents Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-mgmt-agent/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Directory Server 11.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmtc-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Migration Toolkit for Containers for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmtc/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat build of Quarkus 1 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhui-4-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Update Infrastructure 4 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhui/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization 4 Tools Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-tools/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-nfs-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Gluster Storage 3 NFS for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server-nfs/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.3-for-rhel-8-$basearch-source-rpms]
+name = Single Sign-On 7.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.4-for-rhel-8-$basearch-source-rpms]
+name = Single Sign-On 7.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-e4s-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-nhc/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoar-nodejs-10-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Application Runtimes Node.js v10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoar-nodejs/10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-beta-for-rhel-8-$basearch-debug-rpms]
+name = Advanced Virtualization Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/advanced-virt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.12-for-rhel-8-$basearch-debug-rpms]
+name = Logical Volume Manager Storage (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.7-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Directory Server 11.7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Service Interconnect for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.8-for-rhel-8-$basearch-rpms]
+name = Red Hat Certificate System 10.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rhui-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.1-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-debug-rpms]
+name = Red Hat Container Development Kit 3.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 15 Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-8-$basearch-source-rpms]
+name = Kernel Module Management 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/kmm/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhsi-textonly-1-for-middleware-rpms]
+name = Red Hat Service Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhsi/1/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.0-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Pipelines 1.0 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-8-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-8-$basearch-source-rpms]
+name = JBoss Web Server 5 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jws/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoar-nodejs-12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Application Runtimes Node.js v12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoar-nodejs/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.20-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Jaeger 1.20.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[mirror-registry-1-for-rhel-8-$basearch-debug-rpms]
+name = mirror registry for Red Hat OpenShift (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/mirror-registry/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.3 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoss-1.29-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Openshift Serverless 1.29 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoss/1.29/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-devtools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16 Developer Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-devtools/16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2-for-rhel-8-$basearch-textonly-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2 Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm-textonly/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Directory Server 11.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.4-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.4 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-nfs-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Gluster Storage 3 NFS for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server-nfs/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.6-for-rhel-8-$basearch-rpms]
+name = Red Hat Certificate System 10.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/certsys/10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-tus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/openstack/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.4-for-rhel-8-$basearch-rpms]
+name = OpenShift Tools and Services 4.4 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.7-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.5-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Tools and Services 4.5 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-deployment-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 15 Director Deployment Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[source-to-image-1-for-rhel-8-$basearch-rpms]
+name = OpenShift Source-to-Image 1 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/source-to-image/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-0.1.3-for-rhel-8-$basearch-rpms]
+name = Network Observability (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/NETOBSERV/0.1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-debug-rpms]
+name = Red Hat Container Development Kit 3.6 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-e4s-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-tools/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Engine 2.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-nhc/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Builds 1.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Gluster Storage 3 Server for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Builds for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-8-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhbop-textonly-1-for-middleware-rpms]
+name = Red Hat Build of OptaPlanner Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/6/6Server/$basearch/rhbop-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat build of Quarkus 2 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4.4-manager-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization Manager 4.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-manager/4.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/dirsrv/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Builds 1.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-7.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat JBoss Data Grid 7.3 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/7.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Application Interconnect for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhai/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.11-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.11 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/8.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat build of Quarkus 1 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.11-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/dirsrv/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Directory Server 11.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[mirror-registry-1-for-rhel-8-$basearch-source-rpms]
+name = mirror registry for Red Hat OpenShift (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/mirror-registry/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-source-rpms]
+name = Red Hat Container Development Kit 3.6 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-samba-for-rhel-8-$basearch-rpms]
+name = Red Hat Gluster Storage 3 Samba for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server-samba/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[mirror-registry-1-for-rhel-8-$basearch-rpms]
+name = mirror registry for Red Hat OpenShift (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/mirror-registry/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-2.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat build of Quarkus 2.2 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/2.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-e4s-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[devworkspace-0.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Devworkspace 0.10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/devworkspace/0.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/dirsrv/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.3-for-rhel-8-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.3 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.4-for-rhel-8-$basearch-debug-rpms]
+name = Single Sign-On 7.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-textonly-rpms]
+name = Red Hat Discovery 1 Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.7-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-0.1.3-for-rhel-8-$basearch-source-rpms]
+name = Network Observability (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/NETOBSERV/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-ocs-4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Storage 4 Server (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocs-server/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoss-1.29-for-rhel-8-$basearch-rpms]
+name = Red Hat Openshift Serverless 1.29 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoss/1.29/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-ocs-4.6-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat OpenShift Container Storage 4.6 Server EUS (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocs-server/4.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-ee-textonly-rpms]
+name = Red Hat Ansible Automation Platform EE Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform-textonly/ee/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.6-for-rhel-8-$basearch-rpms]
+name = Red Hat Directory Server 11.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.7-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.7 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-textonly-1-for-middleware-rpms]
+name = Red Hat AMQ Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq-interconnect/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 2.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.7-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.11-rpms]
+name = Red Hat Container Development Kit 3.11 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-utils/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-e4s-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.5-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Tools and Services 4.5 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-1-for-rhel-8-$basearch-source-rpms]
+name = JBoss Core Services (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbcs/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.4-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Tools and Services 4.4 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-nfv-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Real Time for NFV (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.3-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Builds 1.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-1-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Core Services (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbcs/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.12-rpms]
+name = Red Hat Container Development Kit 3.12 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1.20-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Science 1.20 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.3-for-rhel-8-$basearch-rhui-source-rpms]
+name = Single Sign-On 7.3 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rh-sso/7.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.15-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Gluster Storage 3 Server for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-mgmt-agent-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Management Agents for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-mgmt-agent/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.22-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Jaeger 1.22.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.22/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-1-for-rhel-8-$basearch-rpms]
+name = JBoss AMQ Interconnect 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq-interconnect/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.1-for-rhel-8-$basearch-rpms]
+name = Red Hat Migration Toolkit 1.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.5-for-rhel-8-$basearch-rpms]
+name = OpenShift Tools and Services 4.5 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Telecommunications Update Service (RPMS)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-8-$basearch-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-client-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Storage Native Client for RHEL 8 (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rhgs-client/3.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cfme-5.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat CloudForms Management Engine for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cfme/5.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.8-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.8 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Web Server 5 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jws/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1-for-rhel-8-$basearch-files]
+name = Red Hat OpenShift Data Science 1 for RHEL 8 $basearch (Files)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1/files
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.9-for-rhel-8-$basearch-rpms]
+name = Red Hat Directory Server 11.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-nfv-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Real Time for NFV (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/nfv/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cluster-observability-operator-1-for-rhel-8-$basearch-textonly-source-rpms]
+name = Cluster Observability Operator (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cluster-observability-operator/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.4-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.7-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.7 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Certificate System 10.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.2-for-rhel-8-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.2 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.17-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.17 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1.20-for-rhel-8-$basearch-files]
+name = Red Hat OpenShift Data Science 1.20 for RHEL 8 $basearch (Files)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1.20/files
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.5-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.7-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-e4s-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-1-for-rhel-8-$basearch-rpms]
+name = JBoss Core Services (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbcs/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.11 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-services-catalog-1-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Automation Services Catalog 1 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/automation-services-catalog/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/8.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.0-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-8-$basearch-source-rpms]
+name = Single Sign-On 7.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-1.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 1.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[3scale-amp-2-rpms-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat 3scale API Management Platform 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/3scale-amp/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-tus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-samba-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Gluster Storage 3 Samba for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server-samba/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Discovery 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.8-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.17-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Jaeger 1.17 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-cinderlib-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16.1 Cinderlib for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rpms]
+name = Single Sign-On Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Enterprise Application Platform Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbeap/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhui-4-for-rhel-8-$basearch-rpms]
+name = Red Hat Update Infrastructure 4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhui/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-snr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.12-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.12 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.4 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-0.1.3-for-rhel-8-$basearch-files]
+name = Network Observability (Files)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/NETOBSERV/1.0/files
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-e4s-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Builds 1.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.15 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.5-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Ansible Engine 2 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-deployment-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16.2 Director Deployment Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-hub-4-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Automation Hub 4 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/automation-hub/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-tus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16 Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.7-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.7 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-beta-for-rhel-8-$basearch-debug-rpms]
+name = Fast Datapath Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/fast-datapath/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-8-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/8.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.1-for-rhel-8-$basearch-rpms]
+name = Red Hat JBoss Data Grid 8.1 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/8.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.20-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Jaeger 1.20.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-nmo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-tus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-mon-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage MON 4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-mon/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Application Interconnect for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhai/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-8-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.5-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.5 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosds-textonly-3-for-middleware-rpms]
+name = Red Hat OpenShift Dev Spaces 3 Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhosds/3.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-samba-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Gluster Storage 3 Samba for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server-samba/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.12-for-rhel-8-$basearch-rpms]
+name = Logical Volume Manager Storage (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.24-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Jaeger 1.24 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.24/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1.3-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-stf/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.11-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-tus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Builds for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[soa-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss SOA Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/soa/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.10-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.10 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/8.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.8-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.8 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-rpms]
+name = Red Hat Container Development Kit 3.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Data Foundation (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhodf/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-8-$basearch-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel8/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-8-$basearch-debug-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/network-observability/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.1-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.13-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.13 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-stf/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-2.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Jaeger 2.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/2.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.12-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.7-for-rhel-8-$basearch-rpms]
+name = Red Hat Directory Server 11.7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-client-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Storage Native Client for RHEL 8 (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rhgs-client/3.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.2-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoar-nodejs-10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Application Runtimes Node.js v10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoar-nodejs/10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.11-for-rhel-8-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.9-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Data Science 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.12-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/openstack-deployment-tools/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-beta-for-rhel-8-$basearch-rpms]
+name = Fast Datapath Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/fast-datapath/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-for-rhel-8-$basearch-rpms]
+name = Red Hat Gluster Storage 3 Server for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-deployment-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16.1 Director Deployment Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cluster-observability-operator-1-for-rhel-8-$basearch-textonly-debug-rpms]
+name = Cluster Observability Operator (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cluster-observability-operator/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-rpms]
+name = Red Hat Container Development Kit 3.6 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-mdr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-8-$basearch-rpms]
+name = Fast Datapath for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/fast-datapath/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Discovery 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-devtools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 15 Developer Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-devtools/15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.0-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Pipelines 1.0 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.10-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.10 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.20-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Jaeger 1.20.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 2.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1.0-for-rhel-8-$basearch-rpms]
+name = Kernel Module Management 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/kmm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.12-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.7-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.7 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.11-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-source-rpms]
+name = Red Hat Container Development Kit 3.5 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.17-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.17 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-3-for-rhel-8-$basearch-rpms]
+name = Red Hat build of Quarkus 3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-8-$basearch-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-8-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.12-for-rhel-8-$basearch-source-rpms]
+name = Logical Volume Manager Storage (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Data Science 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Migration Toolkit 1.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.13 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/dirsrv/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-capsule/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-hub-4.2-for-rhel-8-$basearch-rpms]
+name = Red Hat Automation Hub 4.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/automation-hub/4.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoar-nodejs-12-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Application Runtimes Node.js v12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoar-nodejs/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.2 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-maintenance/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6-beta-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Satellite Tools 6 Beta for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/beta/layered/rhui/rhel8/$basearch/sat-tools/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-nmo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.11 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/codeready-builder/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.17-rpms]
+name = Red Hat Container Development Kit 3.17 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/certsys/10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.9-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.9 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.5-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhui-4-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Update Infrastructure 4 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhui/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.16-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.16 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[custom-metrics-autoscaler-2-for-rhel-8-$basearch-debug-rpms]
+name = Custom Metrics Autoscaler 2 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/custom-metrics-autoscaler/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-2-for-rhel-8-$basearch-rpms]
+name = Red Hat AMQ Clients 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Foundation (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhodf/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-1-for-rhel-8-$basearch-source-rpms]
+name = JBoss AMQ Interconnect 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq-interconnect/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.3-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.3 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.7-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-8-$basearch-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.9-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Ansible Engine 2.9 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-cinderlib-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16 Cinderlib for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Directory Server 11.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-ocs-4.6-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat OpenShift Container Storage 4.6 Server EUS (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocs-server/4.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.14-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.14 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.13-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-8-$basearch-source-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rodoo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.10 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.4-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[devworkspace-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat Devworkspace 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/devworkspace/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-deployment-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16.1 Director Deployment Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-8-$basearch-rpms]
+name = Red Hat Discovery 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-tools-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat OpenStack Platform 15 Tools for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/openstack-tools/15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-deployment-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 15 Director Deployment Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.24-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Jaeger 1.24 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.24/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-tools/6.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rhui-rpms]
+name = Single Sign-On Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8.10/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.5-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Certificate System 10.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-beta-for-rhel-8-$basearch-rpms]
+name = Advanced Virtualization Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/advanced-virt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.14-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.14 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/codeready-builder/source/SRPMS
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.4-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-maintenance/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[interconnect-2-for-rhel-8-$basearch-rpms]
+name = JBoss Interconnect 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/interconnect/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhose-textonly-1-for-middleware-rpms]
+name = Red Hat Middleware Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhose-middleware/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-deployment-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16 Director Deployment Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 2.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-rpms]
+name = Red Hat Container Development Kit 2.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.14-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-tools/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-debug-rpms]
+name = Red Hat Container Development Kit 3.5 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.7-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-cinderlib-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16.2 Cinderlib for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-client-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Storage Native Client for RHEL 8 (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rhgs-client/3.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[mirror-registry-2-for-rhel-8-$basearch-rpms]
+name = mirror registry for Red Hat OpenShift for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/mirror-registry/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-tools/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-8-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-beta-for-rhel-8-s390x-rpms]
+name = Fast Datapath Beta for RHEL 8 IBM z Systems (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/s390x/fast-datapath/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-ember-0.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Ember-CSI 0.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-ember/0.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.3-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Tools and Services 4.3 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-7.3-for-rhel-8-$basearch-rpms]
+name = Red Hat JBoss Data Grid 7.3 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/7.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.13 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-devtools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 15 Developer Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-devtools/15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-deployment-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16.2 Director Deployment Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-aus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.15-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-tus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.8-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Ansible Engine 2.8 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8.10/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4.4-manager-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization Manager 4.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-manager/4.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cfme-5.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat CloudForms Management Engine for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cfme/5.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoai-2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift AI 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoai/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/certsys/10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-osd-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage OSD 4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-osd/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Directory Server 11.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Quay 3.11 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quay/3.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.11-for-rhel-8-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[interconnect-2-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Interconnect 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/interconnect/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.12-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.12 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch (RPMS)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Science 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.10-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.10 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-source-rpms]
+name = Red Hat Container Development Kit 2.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.9 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.3-for-rhel-8-$basearch-debug-rpms]
+name = Single Sign-On 7.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-client-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Storage Native Client for RHEL 8 (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-client/3.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-2.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat AMQ Clients 2.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/2.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-tools/6.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-tools-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat OpenStack Platform 16 Tools for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/openstack-tools/16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.15-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.15 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 2.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3.11-for-rhel-8-$basearch-rpms]
+name = Red Hat Quay 3.11 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quay/3.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.5-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Builds 1.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-deployment-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16.1 Director Deployment Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoar-nodejs-10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Application Runtimes Node.js v10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoar-nodejs/10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.6-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.8-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-tus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8.10/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-8-$basearch-rhui-source-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 8) (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/jbeap/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.15 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-7.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat JBoss Data Grid 7.3 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/7.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fsw-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Fuse Service Works Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/fsw/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Data Science 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-e4s-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-8-$basearch-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/8.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[mirror-registry-2-for-rhel-8-$basearch-source-rpms]
+name = mirror registry for Red Hat OpenShift for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/mirror-registry/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Engine 2.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosdt-3-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift distributed tracing 3 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosdt/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-8-$basearch-rhui-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 8) (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/jbeap/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-textonly-1-for-middleware-rpms]
+name = OpenJDK Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openjdk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Tools Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-tools/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-8-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-1-for-rhel-8-$basearch-rhui-source-rpms]
+name = JBoss Core Services (RHEL 8) (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/jbcs/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.0-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.17-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Jaeger 1.17 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-rt-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Real Time (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8.10/$basearch/rt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Extended Update Support (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-8-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.9-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmtc-for-rhel-8-$basearch-rpms]
+name = Red Hat Migration Toolkit for Containers for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmtc/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.22-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Jaeger 1.22.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.22/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.9-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Ansible Engine 2.9 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8.10/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-8-$basearch-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 8 for Red Hat OpenShift (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/osso/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-client-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Storage Native Client for RHEL 8 (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-client/3.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat build of Quarkus 3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.3-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.3 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6-beta-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Satellite Tools 6 Beta for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/beta/layered/rhui/rhel8/$basearch/sat-tools/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Certificate System 10.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-far/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-4.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability 4.10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cfme-5.11-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat CloudForms Management Engine 5.11 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/cfme/5.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-1.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 1.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-tools/6.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[custom-metrics-autoscaler-2-for-rhel-8-$basearch-source-rpms]
+name = Custom Metrics Autoscaler 2 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/custom-metrics-autoscaler/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[source-to-image-1-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Source-to-Image 1 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/source-to-image/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.5-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.5 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Builds 1.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.7-for-rhel-8-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cert-manager/1.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.7-for-rhel-8-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cert-manager/1.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8.10/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Discovery 0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery/0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-0.1.3-for-rhel-8-$basearch-debug-rpms]
+name = Network Observability (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/NETOBSERV/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.12 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16 Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[3scale-amp-2-rpms-for-rhel-8-$basearch-source-rpms]
+name = Red Hat 3scale API Management Platform 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/3scale-amp/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-ember-0.9-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform Ember-CSI 0.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-ember/0.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jdv-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Virtualization Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jdv/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Kernel Module Management 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/kmm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sat-tools/6.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.1-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-8-$basearch-rpms]
+name = Red Hat Service Interconnect for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.9-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.9 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1.20-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Data Science 1.20 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Data Science 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-crb-for-rhel-8-$basearch-rpms]
+name = Advanced Virtualization CodeReady Builder for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/advanced-virt-crb/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-for-rhel-8-$basearch-source-rpms]
+name = Advanced Virtualization for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/advanced-virt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-beta-for-rhel-8-$basearch-source-rpms]
+name = Advanced Virtualization Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/advanced-virt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8.10/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMS)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8.10/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-mdr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 15 Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-for-rhel-8-$basearch-debug-rpms]
+name = Advanced Virtualization for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/advanced-virt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-snr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6-beta-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Satellite Tools 6 Beta for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/beta/layered/rhui/rhel8/$basearch/sat-tools/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.4-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Single Sign-On 7.4 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rh-sso/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1402242344966420946-key.pem
+sslclientcert = /etc/pki/entitlement/1402242344966420946.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -1,0 +1,12 @@
+packages:
+  - findutils
+  - graphviz
+  - jq
+  - rsync
+  - tar
+contentOrigin:
+  repofiles: ["./redhat.repo"]
+context:
+  containerfile:
+    file: ./Dockerfile-downstream
+arches: [x86_64]

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -1,0 +1,624 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/a/adobe-mappings-cmap-20171205-3.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 2190676
+    checksum: sha256:b913dcb5879c7ecc6b3276968770e3270029a60b1563a406a192c3db5d969b8c
+    name: adobe-mappings-cmap
+    evr: 20171205-3.el8
+    sourcerpm: adobe-mappings-cmap-20171205-3.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/a/adobe-mappings-cmap-deprecated-20171205-3.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 121404
+    checksum: sha256:086f68918adfc0ee63a1f3cb22394d5aaf159e6aee2903ce693c0296b3721096
+    name: adobe-mappings-cmap-deprecated
+    evr: 20171205-3.el8
+    sourcerpm: adobe-mappings-cmap-20171205-3.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/a/adobe-mappings-pdf-20180407-1.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 723620
+    checksum: sha256:b6cc9474c830cf8059b3a60dde46416d2ece114835c8d2a22ef609dbc2974420
+    name: adobe-mappings-pdf
+    evr: 20180407-1.el8
+    sourcerpm: adobe-mappings-pdf-20180407-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/a/atk-2.28.1-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 278108
+    checksum: sha256:5072ec9c8d2d33c8b897cf436040c566d70ac3aa65fe67975992e765fca10e80
+    name: atk
+    evr: 2.28.1-1.el8
+    sourcerpm: atk-2.28.1-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/c/cairo-1.15.12-6.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 735920
+    checksum: sha256:8395c703800c9261454792650649c7df35a6af34b8f254fc4e0bf4c0459d2aa7
+    name: cairo
+    evr: 1.15.12-6.el8
+    sourcerpm: cairo-1.15.12-6.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/f/fribidi-1.0.4-9.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 91588
+    checksum: sha256:576f8635aba31c4b3a54d99ddc918b0d74cff18c6f6125d341607f80618c9d9a
+    name: fribidi
+    evr: 1.0.4-9.el8
+    sourcerpm: fribidi-1.0.4-9.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/g/gd-2.2.5-7.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 147292
+    checksum: sha256:4543ee6b844b0d2414e684c0972d1129ad168774c7e990bf15d98a91a487c8ef
+    name: gd
+    evr: 2.2.5-7.el8
+    sourcerpm: gd-2.2.5-7.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/g/gdk-pixbuf2-modules-2.36.12-6.el8_10.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 111460
+    checksum: sha256:ac7fdd4cee4c3fd59787f59c5bf273e2c1c4a1884259ef03feaa9faeb7da4959
+    name: gdk-pixbuf2-modules
+    evr: 2.36.12-6.el8_10
+    sourcerpm: gdk-pixbuf2-2.36.12-6.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/g/google-droid-sans-fonts-20120715-13.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 2603348
+    checksum: sha256:6e9953f840cafb8811043b7ebf88c6670eb24e652011bdbe2bf2bc416f4a702e
+    name: google-droid-sans-fonts
+    evr: 20120715-13.el8
+    sourcerpm: google-droid-fonts-20120715-13.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/g/graphite2-1.3.10-10.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 124536
+    checksum: sha256:2917eaeca5b9b33ab21feb85ed331e0d09704e0930d70c04ca50883a97e4a61f
+    name: graphite2
+    evr: 1.3.10-10.el8
+    sourcerpm: graphite2-1.3.10-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/g/graphviz-2.40.1-45.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 1923956
+    checksum: sha256:73de49d0c2b9421f5945c7b5f68ccbd880cad6d18f9eaf5550e1d98b4e8b6718
+    name: graphviz
+    evr: 2.40.1-45.el8
+    sourcerpm: graphviz-2.40.1-45.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/g/gtk-update-icon-cache-3.22.30-12.el8_10.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 33096
+    checksum: sha256:a95186b16a53a4706f3a84476a9f0ab547c2f36f99fa1a9b1fa66455b14c426a
+    name: gtk-update-icon-cache
+    evr: 3.22.30-12.el8_10
+    sourcerpm: gtk3-3.22.30-12.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/g/gtk2-2.24.32-5.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 3616452
+    checksum: sha256:8a994138b4d4bbcc5663ba464b85c9a9a0112bf9bad7e1ac3302559b69e7fa55
+    name: gtk2
+    evr: 2.24.32-5.el8
+    sourcerpm: gtk2-2.24.32-5.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/h/harfbuzz-1.7.5-4.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 302876
+    checksum: sha256:90a04d6a0c81f6d7f311a7dccba1b0d146f5db315e49d304f76f4e2fc768e0c2
+    name: harfbuzz
+    evr: 1.7.5-4.el8
+    sourcerpm: harfbuzz-1.7.5-4.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/h/hicolor-icon-theme-0.17-2.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 49600
+    checksum: sha256:66bab4d22c2d9f29dc7c7651afa44456e306c6c9c175f96f5021b1887d9a5796
+    name: hicolor-icon-theme
+    evr: 0.17-2.el8
+    sourcerpm: hicolor-icon-theme-0.17-2.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/j/jasper-libs-2.0.14-6.el8_10.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 170656
+    checksum: sha256:712c2679d8acc76f2d7492dc2fc796ba5b409026f4b95d4fb85bebc52981c445
+    name: jasper-libs
+    evr: 2.0.14-6.el8_10
+    sourcerpm: jasper-2.0.14-6.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/j/jbig2dec-libs-0.16-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 73256
+    checksum: sha256:34d5715d9c2f4c6cc8295512789c72c551df8c3c4c38d41581ace16b90c73d36
+    name: jbig2dec-libs
+    evr: 0.16-1.el8
+    sourcerpm: jbig2dec-0.16-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/j/jbigkit-libs-2.1-14.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 55980
+    checksum: sha256:5a55a840cccc45aef19b261cfff264420d28fcb31351b57da85d067fda73d7b7
+    name: jbigkit-libs
+    evr: 2.1-14.el8
+    sourcerpm: jbigkit-2.1-14.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/j/jq-1.6-9.el8_10.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 207896
+    checksum: sha256:baaa3660d87c4f3c12776e051b7f13835fee8918389a57673519e3389eb7aa3b
+    name: jq
+    evr: 1.6-9.el8_10
+    sourcerpm: jq-1.6-9.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/lcms2-2.9-2.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 168568
+    checksum: sha256:7f2796df5a80f13ea11b3988175cc34cc2964d411480114c6c94671f054adf43
+    name: lcms2
+    evr: 2.9-2.el8
+    sourcerpm: lcms2-2.9-2.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libICE-1.0.9-15.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 75608
+    checksum: sha256:ab35a04e5f165b30e22368b0b51071949e277a42861092b790cfbee283d474b8
+    name: libICE
+    evr: 1.0.9-15.el8
+    sourcerpm: libICE-1.0.9-15.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libSM-1.2.3-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 48704
+    checksum: sha256:db15deba4b67c54368ae5fee595d7266391c27d5a08b65d3307def5861e8f08a
+    name: libSM
+    evr: 1.2.3-1.el8
+    sourcerpm: libSM-1.2.3-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libX11-1.6.8-9.el8_10.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 626860
+    checksum: sha256:9c4012d2aaf2e9d1c5a7f315dd284b2df9380d40c2c928507de55585d3404ccf
+    name: libX11
+    evr: 1.6.8-9.el8_10
+    sourcerpm: libX11-1.6.8-9.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libX11-common-1.6.8-9.el8_10.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 162348
+    checksum: sha256:558399ee08f1281a9e2eff4c0bbc3756d374d0e543587bcf2c12e557df479cc6
+    name: libX11-common
+    evr: 1.6.8-9.el8_10
+    sourcerpm: libX11-1.6.8-9.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXau-1.0.9-3.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 38312
+    checksum: sha256:a260f793e49805b188908e2f30c4687abe4e023b20c28a85d10d2371556c3981
+    name: libXau
+    evr: 1.0.9-3.el8
+    sourcerpm: libXau-1.0.9-3.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXaw-1.0.13-10.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 198848
+    checksum: sha256:12f34b20a058f274a3d26ba186fce744d4233bfc000b181ab2e550693991a6fe
+    name: libXaw
+    evr: 1.0.13-10.el8
+    sourcerpm: libXaw-1.0.13-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXcomposite-0.4.4-14.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 29208
+    checksum: sha256:731f537d1872b14290514b5a956c8c012a781f209a6a209ad9ba2cae1c56c388
+    name: libXcomposite
+    evr: 0.4.4-14.el8
+    sourcerpm: libXcomposite-0.4.4-14.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXcursor-1.1.15-3.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 36728
+    checksum: sha256:f75e90c48ab7c823d22717c4c28324a2add144a230f1298486715cff1cf0152b
+    name: libXcursor
+    evr: 1.1.15-3.el8
+    sourcerpm: libXcursor-1.1.15-3.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXdamage-1.1.4-14.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 27352
+    checksum: sha256:2da144f494567dea106daaa85ac1bc4aed74dbd0eb9224d74209930c468c8649
+    name: libXdamage
+    evr: 1.1.4-14.el8
+    sourcerpm: libXdamage-1.1.4-14.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXext-1.3.4-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 46516
+    checksum: sha256:ddafccd3f010fc75da6de158b5a68fd672f8b3554ac403065490318ce2be05f3
+    name: libXext
+    evr: 1.3.4-1.el8
+    sourcerpm: libXext-1.3.4-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXfixes-5.0.3-7.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 25536
+    checksum: sha256:42cd48bff06dee66716b6a6362d6469168d4657511fcf3bd16003c441dc88fea
+    name: libXfixes
+    evr: 5.0.3-7.el8
+    sourcerpm: libXfixes-5.0.3-7.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXft-2.3.3-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 68352
+    checksum: sha256:9b079ce20a6524d8e85d139b2ec2a7dd3f4f79fa283f68208b72b8091e6bde3b
+    name: libXft
+    evr: 2.3.3-1.el8
+    sourcerpm: libXft-2.3.3-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXi-1.7.10-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 49876
+    checksum: sha256:efc45d8d4a0227c6f104cc45622b2251b198dd830aeb1cacd5c47dcd67da7186
+    name: libXi
+    evr: 1.7.10-1.el8
+    sourcerpm: libXi-1.7.10-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXinerama-1.1.4-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 15936
+    checksum: sha256:9226efc49ff191d0d713446e8b28bb58ae4ab1cb64e34a6f7fc08af247202cdd
+    name: libXinerama
+    evr: 1.1.4-1.el8
+    sourcerpm: libXinerama-1.1.4-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXmu-1.1.3-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 77272
+    checksum: sha256:25603514b1a6851156bab1f197c90ac0f164e4a2a76a0ced10fe10cca8724760
+    name: libXmu
+    evr: 1.1.3-1.el8
+    sourcerpm: libXmu-1.1.3-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXpm-3.5.12-11.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 60128
+    checksum: sha256:108007a3991c3cd289207431c7a529ff500080bfac7102eedae65c9ccb25ccb3
+    name: libXpm
+    evr: 3.5.12-11.el8
+    sourcerpm: libXpm-3.5.12-11.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXrandr-1.5.2-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 34436
+    checksum: sha256:34b08ea266a4bbddffe8307693742c11a09c3dc2a9f271f95a7ab5c4f67ea3e3
+    name: libXrandr
+    evr: 1.5.2-1.el8
+    sourcerpm: libXrandr-1.5.2-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXrender-0.9.10-7.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 33568
+    checksum: sha256:871672b8a9ffbe887b32e736494c1f005795bc7ffda026c6a063ee0d28788709
+    name: libXrender
+    evr: 0.9.10-7.el8
+    sourcerpm: libXrender-0.9.10-7.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXt-1.1.5-12.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 189776
+    checksum: sha256:83f898359716704d06c4762b17ad15a65cd8ea31b1df5d1e6b45c559cac14d47
+    name: libXt
+    evr: 1.1.5-12.el8
+    sourcerpm: libXt-1.1.5-12.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXxf86misc-1.0.4-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 23616
+    checksum: sha256:f061b428add88f6f182f40e74feaf1d602cc98e69ef389db09f272f1e55a0f30
+    name: libXxf86misc
+    evr: 1.0.4-1.el8
+    sourcerpm: libXxf86misc-1.0.4-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libXxf86vm-1.1.4-9.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 19620
+    checksum: sha256:c051509ace6612d97eb1a9dd0514360889fd7fbe42c7b8e207fb6e09bab4f832
+    name: libXxf86vm
+    evr: 1.1.4-9.el8
+    sourcerpm: libXxf86vm-1.1.4-9.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libdatrie-0.2.9-7.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 33932
+    checksum: sha256:95d7e5810a279383b792dcc0656b539ffdce847b2b51730ee45f1af46fe994d4
+    name: libdatrie
+    evr: 0.2.9-7.el8
+    sourcerpm: libdatrie-0.2.9-7.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libfontenc-1.1.3-8.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 37636
+    checksum: sha256:5b2545c178e52a79fd09414db8788d4c9f96b48f6e4d568c762e70b56b4858e8
+    name: libfontenc
+    evr: 1.1.3-8.el8
+    sourcerpm: libfontenc-1.1.3-8.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libgs-9.27-16.el8_10.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 3213584
+    checksum: sha256:69747333b4f689bf00e5ae3153449d30773f09bfca06ed0bbd9509b98222a766
+    name: libgs
+    evr: 9.27-16.el8_10
+    sourcerpm: ghostscript-9.27-16.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libidn-1.34-5.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 244396
+    checksum: sha256:3447f8055b584ad4c36f4282619bb39d1daf3d167957a48953e8f136e6839b11
+    name: libidn
+    evr: 1.34-5.el8
+    sourcerpm: libidn-1.34-5.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libijs-0.35-5.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 30400
+    checksum: sha256:a0e034c93eafb41f4f7759236108775b7c64dd2a2967b3847e214f3a9908e064
+    name: libijs
+    evr: 0.35-5.el8
+    sourcerpm: libijs-0.35-5.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libjpeg-turbo-1.5.3-12.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 160920
+    checksum: sha256:82dba75523110a451d9f4dbb112c68ba15b1cded1519bc982423de032903dbc9
+    name: libjpeg-turbo
+    evr: 1.5.3-12.el8
+    sourcerpm: libjpeg-turbo-1.5.3-12.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libmcpp-2.7.2-20.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 82908
+    checksum: sha256:75e62553eeab9fe76d99a2413412e5c9663596e4eef8cf75e81031f8b3c40c35
+    name: libmcpp
+    evr: 2.7.2-20.el8
+    sourcerpm: mcpp-2.7.2-20.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libpaper-1.1.24-22.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 45680
+    checksum: sha256:86ebcf47eb98fcf9b947b02cb514e3a4aa7b1215a3bc6c1612614f8688b772e1
+    name: libpaper
+    evr: 1.1.24-22.el8
+    sourcerpm: libpaper-1.1.24-22.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/librsvg2-2.42.7-5.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 588588
+    checksum: sha256:d14e0f27e0ff66799661c83daf2fdca7fbe2f5137b0e9f79816010b1e8443079
+    name: librsvg2
+    evr: 2.42.7-5.el8
+    sourcerpm: librsvg2-2.42.7-5.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libthai-0.1.27-2.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 207716
+    checksum: sha256:3d203f221eb11b5a0a216427dee391294b0fb3aa0bc3348fd0d4330556a9b011
+    name: libthai
+    evr: 0.1.27-2.el8
+    sourcerpm: libthai-0.1.27-2.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libtiff-4.0.9-33.el8_10.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 194928
+    checksum: sha256:c45f5fef1b5786527ee8a5e3c29e6de1effe09af3fa791870208a6c9318c7d50
+    name: libtiff
+    evr: 4.0.9-33.el8_10
+    sourcerpm: libtiff-4.0.9-33.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libwebp-1.0.0-9.el8_9.1.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 280472
+    checksum: sha256:e30e48384630f9c997cae4a5ab718ea91f426832e06b71db4da0a7d16cfcf600
+    name: libwebp
+    evr: 1.0.0-9.el8_9.1
+    sourcerpm: libwebp-1.0.0-9.el8_9.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libxcb-1.13.1-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 234420
+    checksum: sha256:39e6bc1e8101e536066554702d5d6b25f8cad359fb5e02ac598cfdad56eafb6d
+    name: libxcb
+    evr: 1.13.1-1.el8
+    sourcerpm: libxcb-1.13.1-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/m/mcpp-2.7.2-20.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 32228
+    checksum: sha256:efa2613a6f9b2e796cb7a8b1e243f8d15be0866ea71e9226b0a092ddefef3ec8
+    name: mcpp
+    evr: 2.7.2-20.el8
+    sourcerpm: mcpp-2.7.2-20.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/o/oniguruma-6.8.2-3.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 192632
+    checksum: sha256:1c5c91d8a33987892ec7320c08311a31245be91800aa5879e20d137971bd053f
+    name: oniguruma
+    evr: 6.8.2-3.el8
+    sourcerpm: oniguruma-6.8.2-3.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/o/openjpeg2-2.4.0-5.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 169012
+    checksum: sha256:936f9d627574c4cdf571d034dcc4a03c9d623f6a275c8d83deac055a55f529dd
+    name: openjpeg2
+    evr: 2.4.0-5.el8
+    sourcerpm: openjpeg2-2.4.0-5.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/p/pango-1.42.4-8.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 304480
+    checksum: sha256:d0e41cd47e15807906792aaff4ebc2502efc63548e09da456b105748129d09b9
+    name: pango
+    evr: 1.42.4-8.el8
+    sourcerpm: pango-1.42.4-8.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/p/pixman-0.38.4-4.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 263800
+    checksum: sha256:7b463191aeedc6c0dde44a0196c708cade83c24d643829e50e0656e8383f78ae
+    name: pixman
+    evr: 0.38.4-4.el8
+    sourcerpm: pixman-0.38.4-4.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/u/urw-base35-bookman-fonts-20170801-10.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 877408
+    checksum: sha256:da844cfd35bf0bb946885f0d23c45873ebd2f48753747c1355eec5571af63827
+    name: urw-base35-bookman-fonts
+    evr: 20170801-10.el8
+    sourcerpm: urw-base35-fonts-20170801-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/u/urw-base35-c059-fonts-20170801-10.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 905124
+    checksum: sha256:aa0dcea600b69b6dbd6176c78c4cdc7fe2e28edcb71433df926aabd896e299ab
+    name: urw-base35-c059-fonts
+    evr: 20170801-10.el8
+    sourcerpm: urw-base35-fonts-20170801-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/u/urw-base35-d050000l-fonts-20170801-10.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 81200
+    checksum: sha256:cdfae9c90d009a6de249a108d398a9a216f8953d3386d4a7352a761127abd1b2
+    name: urw-base35-d050000l-fonts
+    evr: 20170801-10.el8
+    sourcerpm: urw-base35-fonts-20170801-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/u/urw-base35-fonts-20170801-10.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 12480
+    checksum: sha256:9d398eb2d7658216f9b8e90d00c5359a85596cafafd94febaceb516b62c02026
+    name: urw-base35-fonts
+    evr: 20170801-10.el8
+    sourcerpm: urw-base35-fonts-20170801-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/u/urw-base35-fonts-common-20170801-10.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 23872
+    checksum: sha256:10a2c21e87ed50aeecc56b7527fc4a872b85bf3c40d4c5dde96ae17abca93895
+    name: urw-base35-fonts-common
+    evr: 20170801-10.el8
+    sourcerpm: urw-base35-fonts-20170801-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/u/urw-base35-gothic-fonts-20170801-10.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 670068
+    checksum: sha256:91f2071c95278d5e50d02394be50e954c650d2adfc36713227700a52789c68cd
+    name: urw-base35-gothic-fonts
+    evr: 20170801-10.el8
+    sourcerpm: urw-base35-fonts-20170801-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/u/urw-base35-nimbus-mono-ps-fonts-20170801-10.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 820196
+    checksum: sha256:8fc64ceb2ae825f607e52e121fb518494bb6a0ebc77c6f06465c5a88576751ef
+    name: urw-base35-nimbus-mono-ps-fonts
+    evr: 20170801-10.el8
+    sourcerpm: urw-base35-fonts-20170801-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/u/urw-base35-nimbus-roman-fonts-20170801-10.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 885612
+    checksum: sha256:0eb3491251bbe7c63728bd613c97b2d3259508728cca56a9599f705e08cdc020
+    name: urw-base35-nimbus-roman-fonts
+    evr: 20170801-10.el8
+    sourcerpm: urw-base35-fonts-20170801-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/u/urw-base35-nimbus-sans-fonts-20170801-10.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 1352712
+    checksum: sha256:24cabc33faad2b2e3fb1049c61bffe5adaefd19a63f1db5d17609fe181c1cbb5
+    name: urw-base35-nimbus-sans-fonts
+    evr: 20170801-10.el8
+    sourcerpm: urw-base35-fonts-20170801-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/u/urw-base35-p052-fonts-20170801-10.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 1005916
+    checksum: sha256:29dd088431ac9574ebed65d7a1d230ae0d51966ec9dbb3fab1ad56df885eb46a
+    name: urw-base35-p052-fonts
+    evr: 20170801-10.el8
+    sourcerpm: urw-base35-fonts-20170801-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/u/urw-base35-standard-symbols-ps-fonts-20170801-10.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 45212
+    checksum: sha256:066088d80513ff407adcf716143b5958a24ea32f0ef58b3aed51c4c4d341bec7
+    name: urw-base35-standard-symbols-ps-fonts
+    evr: 20170801-10.el8
+    sourcerpm: urw-base35-fonts-20170801-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/u/urw-base35-z003-fonts-20170801-10.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 286164
+    checksum: sha256:e2e2af0d3461987ee1bcc0a6aedf798f907c3b680c687d4179359186f5dc387c
+    name: urw-base35-z003-fonts
+    evr: 20170801-10.el8
+    sourcerpm: urw-base35-fonts-20170801-10.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/x/xorg-x11-font-utils-7.5-41.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 106144
+    checksum: sha256:966566770c97b65d5c2d743631322241fc8508f56c2698fc706bd7dba3761199
+    name: xorg-x11-font-utils
+    evr: 1:7.5-41.el8
+    sourcerpm: xorg-x11-font-utils-7.5-41.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/x/xorg-x11-fonts-ISO8859-1-100dpi-7.5-19.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 1109848
+    checksum: sha256:460d123daa11f00f22164e841d49886b8852fef5a7ebf08d6c4f2b719fe8b43f
+    name: xorg-x11-fonts-ISO8859-1-100dpi
+    evr: 7.5-19.el8
+    sourcerpm: xorg-x11-fonts-7.5-19.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/x/xorg-x11-server-utils-7.7-27.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-appstream-rpms
+    size: 202016
+    checksum: sha256:c248785c584b6142288e834ce34f5ac703c7ebce94c5ff60f4fd40c229493909
+    name: xorg-x11-server-utils
+    evr: 7.7-27.el8
+    sourcerpm: xorg-x11-server-utils-7.7-27.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/a/avahi-libs-0.7-27.el8_10.1.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 63848
+    checksum: sha256:f2f4b6a3501e339521c5e5f00e96fa06655535b564c24daa706a9064d543ae2c
+    name: avahi-libs
+    evr: 0.7-27.el8_10.1
+    sourcerpm: avahi-0.7-27.el8_10.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/c/cups-libs-2.2.6-62.el8_10.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 448028
+    checksum: sha256:b4082915e95fa77e369d024433dc0b01017f784cfb5b03b5f3fe516f95d510ec
+    name: cups-libs
+    evr: 1:2.2.6-62.el8_10
+    sourcerpm: cups-2.2.6-62.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/e/emacs-filesystem-26.1-13.el8_10.noarch.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 72256
+    checksum: sha256:00cd8d7a426bfd9c80fc94077b0c87a8a7d60cd90442dc7665f6f8676452bcd7
+    name: emacs-filesystem
+    evr: 1:26.1-13.el8_10
+    sourcerpm: emacs-26.1-13.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/f/fontconfig-2.13.1-4.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 280836
+    checksum: sha256:7f2a8ed367bbe341e4c7570746cdeada3b68f6d1e498b411748b972190bce95c
+    name: fontconfig
+    evr: 2.13.1-4.el8
+    sourcerpm: fontconfig-2.13.1-4.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/f/fontpackages-filesystem-1.44-22.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 16324
+    checksum: sha256:db1fad3c2d8735e69084bd4b09ea963938e4dde2f2e096dc7a4ce146f18b7ab0
+    name: fontpackages-filesystem
+    evr: 1.44-22.el8
+    sourcerpm: fontpackages-1.44-22.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/f/freetype-2.9.1-10.el8_10.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 403276
+    checksum: sha256:2ef3b0f9975f2c7d9f3ca3d336efa90cffdb8101f594e7e0cf1a3b7efdb8f14e
+    name: freetype
+    evr: 2.9.1-10.el8_10
+    sourcerpm: freetype-2.9.1-10.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/g/gdk-pixbuf2-2.36.12-6.el8_10.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 477652
+    checksum: sha256:5181f4e31412ff38a53b392799d55ec0bb6876104ba68aa930a4e99d4128a651
+    name: gdk-pixbuf2
+    evr: 2.36.12-6.el8_10
+    sourcerpm: gdk-pixbuf2-2.36.12-6.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libcroco-0.6.12-4.el8_2.1.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 115260
+    checksum: sha256:d0982bac60512aaf37a99078e24446337ab6210db07ed95c49baeb9a3811dd2b
+    name: libcroco
+    evr: 0.6.12-4.el8_2.1
+    sourcerpm: libcroco-0.6.12-4.el8_2.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libpkgconf-1.4.2-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 35620
+    checksum: sha256:96fadfed6a8225a89b331e7b62ed8ee74b393cea1520fa0d89f6f0dc1a458fb3
+    name: libpkgconf
+    evr: 1.4.2-1.el8
+    sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libpng-1.6.34-5.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 129016
+    checksum: sha256:53d9bb412615966acdf9a6b1c26c5899a9c2c0b76a27f360d3d6076536d2540a
+    name: libpng
+    evr: 2:1.6.34-5.el8
+    sourcerpm: libpng-1.6.34-5.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libtool-ltdl-2.4.6-25.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 59180
+    checksum: sha256:d805c42ee9293a8ba35f49af63e3f7d813420d4a62ee4cff5ecd7391be851a9b
+    name: libtool-ltdl
+    evr: 2.4.6-25.el8
+    sourcerpm: libtool-2.4.6-25.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/p/pkgconf-1.4.2-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 38956
+    checksum: sha256:b9d0a4c0e16db4c05b2d0690216d8c5da2db7d67bc765a00ce2a32c5f810c245
+    name: pkgconf
+    evr: 1.4.2-1.el8
+    sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/p/pkgconf-m4-1.4.2-1.el8.noarch.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 17484
+    checksum: sha256:9a89874a5b8326c85c0b34b02c122ffc052b32a12b20354ce95859ac5296a159
+    name: pkgconf-m4
+    evr: 1.4.2-1.el8
+    sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.4.2-1.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 15628
+    checksum: sha256:1c4a8674eafc31d36030f3fd0c081326d4301570d4e35b59d6f6ef1e163f655b
+    name: pkgconf-pkg-config
+    evr: 1.4.2-1.el8
+    sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
+  source: []
+  module_metadata: []


### PR DESCRIPTION
This enables hermetic builds of forklift-must-gather image in Konflux.

Changes:
- Add downstream containerfiles
- Enable hermetic builds in build pipelines
- Add rpms.in.yaml, rpms.lock.yaml and redhat.repo files