### PR TITLE
Add missing args

### DIFF
--- a/build/Dockerfile-downstream
+++ b/build/Dockerfile-downstream
@@ -10,6 +10,9 @@ COPY collection-scripts/* /usr/bin/
 
 ENTRYPOINT ["/usr/bin/gather"]
 
+ARG VERSION
+ARG REGISTRY
+
 LABEL \
     com.redhat.component="mtv-must-gather-container" \
     version="$VERSION" \


### PR DESCRIPTION
Add missing args instructions into dockerfile for konflux build-args-file.