### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for forklift-must-gather-2-8

### DIFF
--- a/build/Dockerfile-downstream
+++ b/build/Dockerfile-downstream
@@ -25,4 +25,5 @@ LABEL \
     summary="Migration Toolkit for Virtualization - Must Gather" \
     description="Migration Toolkit for Virtualization - Must Gather" \
     maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.8::el8" \
     revision="$REVISION"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
