### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for forklift-must-gather-dev-preview

### DIFF
--- a/build/Dockerfile-downstream
+++ b/build/Dockerfile-downstream
@@ -16,6 +16,7 @@ ARG REVISION
 
 LABEL \
     com.redhat.component="mtv-must-gather-container" \
+    cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el8" \
     version="$VERSION" \
     name="${REGISTRY}/mtv-must-gather-rhel8" \
     license="Apache License 2.0" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
