### PR TITLE
fix: collect DVs, PVCs, and populate pod logs when VMs don't exist yet

### DIFF
--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -165,7 +165,56 @@ if [ ! -z "${vm_resources}" ]; then
         # Store VM in list to allow virt-launcher pod logs gathering
         echo "${target_ns},${target_vm_name},${target_vm_id}" >> /tmp/target_vms
       else
-        echo "VirtualMachine ${target_vm_name} doesn't exist in ${target_ns} namespace, skipping."
+        echo "VirtualMachine ${target_vm_name} doesn't exist in ${target_ns} namespace, collecting resources from plan status."
+
+        # Even without a VM CR, collect DVs, PVCs, and migration data from the plan status.
+        # During the populate phase, VMs don't exist yet but DVs, PVCs, and populate pods do.
+        # Namespace-wide collection only needs to happen once, tracked via /tmp/ns_collected.
+        if [ ! -f /tmp/ns_collected ]; then
+          migration_uid=""
+          for plan_id in ${plan_resources[@]}; do
+            migration_uid=$(/usr/bin/oc get plan $plan_id -n ${target_ns} -o jsonpath='{.status.migration.history[0].migration.uid}' 2>/dev/null)
+            if [ ! -z "$migration_uid" ]; then
+              log_filter_query="$log_filter_query|$migration_uid"
+              echo ${migration_uid} >> /tmp/migrations
+              break
+            fi
+          done
+
+          if [ ! -z "$migration_uid" ]; then
+            # Collect PVCs and DVs scoped by migration label
+            for pvc_name in $(/usr/bin/oc get pvc --no-headers -n ${target_ns} --selector migration=$migration_uid -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' 2>/dev/null); do
+              log_filter_query="$log_filter_query|$pvc_name"
+              dump_resource "persistentvolumeclaim" $pvc_name $target_ns
+              echo "${target_ns},${pvc_name}" >> /tmp/pvcs
+            done
+
+            for dv_name in $(/usr/bin/oc get datavolume --no-headers -n ${target_ns} --selector migration=$migration_uid -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' 2>/dev/null); do
+              dump_resource "datavolume" $dv_name $target_ns
+              echo "${target_ns},${dv_name}" >> /tmp/dvs
+            done
+          fi
+
+          # Fallback: if no migration-scoped resources found, collect all PVCs and DVs in the namespace
+          if [ ! -s /tmp/pvcs ]; then
+            for pvc_name in $(/usr/bin/oc get pvc --no-headers -n ${target_ns} -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' 2>/dev/null); do
+              log_filter_query="$log_filter_query|$pvc_name"
+              dump_resource "persistentvolumeclaim" $pvc_name $target_ns
+              echo "${target_ns},${pvc_name}" >> /tmp/pvcs
+            done
+
+            for dv_name in $(/usr/bin/oc get datavolume --no-headers -n ${target_ns} -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' 2>/dev/null); do
+              dump_resource "datavolume" $dv_name $target_ns
+              echo "${target_ns},${dv_name}" >> /tmp/dvs
+            done
+          fi
+
+          # Store target namespace for targeted_logs fallback
+          echo ${target_ns} > /tmp/target_ns
+          touch /tmp/ns_collected
+        fi
+
+        log_filter_query="$log_filter_query|$target_vm_name"
       fi
     done
 fi
@@ -176,10 +225,10 @@ if [ -z $plan_resources ] && [ -z $vm_resources ] && [ -z $dv_resources ]; then
   exit 1
 fi
 
-# Show message for zero valid VMs without Plan of resources actually existing in the cluster
+# Show message for zero valid VMs without Plan of resources actually existing in the cluster.
+# This is not an error when VMs don't exist yet (e.g. during populate phase).
 if [ -z $plan_resources ] && [ -z $present_vm_resources ]; then
-  echo "ERROR: No existing VMs were found in the cluster."
-  exit 1
+  echo "WARNING: No existing VMs were found in the cluster. Resources may still be collected from plan status."
 fi
 
 # Store condition for logs filtering

--- a/collection-scripts/targeted_logs
+++ b/collection-scripts/targeted_logs
@@ -85,6 +85,25 @@ for nsvm in ${target_vms[@]}; do
   done
 done
 
+# Collect populate pod logs directly from migration labels when VMs don't exist yet.
+# During the populate phase, VMs are not created but populate pods are running.
+if [[ -z "${target_vms}" && ! -z "${target_migrations}" ]]; then
+  target_ns="$(touch /tmp/target_ns; cat /tmp/target_ns)"
+  if [[ ! -z "${target_ns}" ]]; then
+    echo "No target VMs found, collecting populate pods directly from migration labels..."
+    for migration in ${target_migrations[@]}; do
+      read migration_id <<< $migration
+      for populatorPod in $(oc get pods --no-headers -n $target_ns --selector migration=$migration_id,pvcName -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' 2>/dev/null); do
+        object_collection_path="/must-gather/namespaces/${target_ns}/logs/${populatorPod}"
+        mkdir -p ${object_collection_path}
+        echo "[ns=${target_ns}][pod=${populatorPod}] Collecting Populator Pod logs (no VM)..."
+        /usr/bin/oc logs --all-containers --namespace ${target_ns} ${populatorPod} &> "${object_collection_path}/current.log" &
+        pwait $max_parallelism
+      done
+    done
+  fi
+fi
+
 # Collect CDI/importer pod logs for imported DVs
 for nsdv in ${target_dvs[@]}; do
   IFS="," read ns dv <<< $nsdv


### PR DESCRIPTION
## Problem

The targeted must-gather script fails to collect populate pods, DataVolumes, PVCs, and their logs when a migration fails during the populate/disk-copy phase.

The collection logic in `targeted_crs` is VM-centric:
1. Reads VM names from `plan.status.migration.vms[].name`
2. Checks if each `VirtualMachine` CR exists in the cluster
3. **Only then** collects DVs, PVCs, populate pods, and logs for those VMs

During the populate phase, `VirtualMachine` CRs don't exist yet - they are created only after disks are fully populated. If the migration fails mid-copy, the script finds no VMs and skips all downstream resources.

## Impact

- Populate pod logs (containing critical debug info like `xcopyUsed` values for copy-offload/XCOPY migrations) are **not collected**
- DataVolume and PVC CRs from the target namespace are **not collected**
- CDI importer pod logs are **not collected**
- Only the Plan CR is present in the must-gather output

## Fix

### `targeted_crs`
- When a VM doesn't exist, fall back to collecting **all DVs and PVCs** directly from the target namespace
- Extract migration UID from plan status to enable populate pod log collection via `/tmp/migrations`
- Change the "no VMs found" error to a warning, since resources can still be collected from plan status

### `targeted_logs`
- Add fallback populate pod log collection using migration labels when no target VMs were discovered
- Collects all pods with the `migration` label in the target namespace

Resolves: #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-time collection when a specified VM is missing: captures related migration and storage objects and augments log filters with migration and VM identifiers.
  * Added populate-pod-only log collection when migrations exist but target VMs are not present, with parallelized log gathering.

* **Bug Fixes**
  * Treats "no existing VMs found" as a non-fatal warning instead of exiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->