### PR TITLE
fix: collect virt-v2v pod logs when VMs do not exist yet

### DIFF
--- a/collection-scripts/targeted_logs
+++ b/collection-scripts/targeted_logs
@@ -85,19 +85,19 @@ for nsvm in ${target_vms[@]}; do
   done
 done
 
-# Collect populate pod logs directly from migration labels when VMs don't exist yet.
-# During the populate phase, VMs are not created but populate pods are running.
+# Collect migration-related pod logs when VMs don't exist yet.
+# During the populate/conversion phase, VMs may not be created but migration pods are running.
 if [[ -z "${target_vms}" && ! -z "${target_migrations}" ]]; then
   target_ns="$(touch /tmp/target_ns; cat /tmp/target_ns)"
   if [[ ! -z "${target_ns}" ]]; then
-    echo "No target VMs found, collecting populate pods directly from migration labels..."
+    echo "No target VMs found, collecting migration-related pods directly from migration labels..."
     for migration in ${target_migrations[@]}; do
       read migration_id <<< $migration
-      for populatorPod in $(oc get pods --no-headers -n $target_ns --selector migration=$migration_id,pvcName -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' 2>/dev/null); do
-        object_collection_path="/must-gather/namespaces/${target_ns}/logs/${populatorPod}"
+      for pod in $(oc get pods --no-headers -n $target_ns --selector migration=$migration_id -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' 2>/dev/null); do
+        object_collection_path="/must-gather/namespaces/${target_ns}/logs/${pod}"
         mkdir -p ${object_collection_path}
-        echo "[ns=${target_ns}][pod=${populatorPod}] Collecting Populator Pod logs (no VM)..."
-        /usr/bin/oc logs --all-containers --namespace ${target_ns} ${populatorPod} &> "${object_collection_path}/current.log" &
+        echo "[ns=${target_ns}][pod=${pod}] Collecting migration Pod logs (no VM)..."
+        /usr/bin/oc logs --all-containers --namespace ${target_ns} ${pod} &> "${object_collection_path}/current.log" &
         pwait $max_parallelism
       done
     done


### PR DESCRIPTION
Issue: When targeted must-gather runs with PLAN= filter and virt-v2v conversion fails before a VM CR is created, the VM loop is empty and virt-v2v pod logs are never collected. The existing fallback for the no-VMs case only collected populator pods (selector: migration=$id,pvcName), missing the virt-v2v logs which contain the root cause of the conversion failure.
(The same problem as addressed by https://github.com/kubev2v/forklift-must-gather/pull/247, only including virt-v2v pod's log)

Fix: Widen the pod selector in the no-VMs fallback block from migration=$id,pvcName to migration=$id, catching all migration-related pods including virt-v2v.

Resolves: None

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration diagnostic log collection with enhanced pod identification and clearer log naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->