### PR TITLE
feat: add MUST_GATHER_SINCE and MUST_GATHER_SINCE_TIME time-based log filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,30 @@ VM name together with namespace where the VM belongs to
 oc adm must-gather --image=quay.io/kubev2v/forklift-must-gather:latest -- NS=ns1 VM=vm-3345 /usr/bin/targeted
 ```
 
+### Time-based log filtering
+
+To limit the amount of collected log data, you can restrict logs to a specific time window. This is useful when collecting logs from long-running pods (e.g. `forklift-controller`) where only recent logs are relevant.
+
+Collect logs from the last 2 hours:
+
+```sh
+oc adm must-gather --image=quay.io/kubev2v/forklift-must-gather:latest -- MUST_GATHER_SINCE=2h /usr/bin/gather
+```
+
+Collect logs since a specific timestamp (RFC 3339 format):
+
+```sh
+oc adm must-gather --image=quay.io/kubev2v/forklift-must-gather:latest -- MUST_GATHER_SINCE_TIME=2024-04-22T10:00:00Z /usr/bin/gather
+```
+
+These parameters also work with targeted gathering:
+
+```sh
+oc adm must-gather --image=quay.io/kubev2v/forklift-must-gather:latest -- MUST_GATHER_SINCE=2h NS=ns1 PLAN=plan1 /usr/bin/targeted
+```
+
+When both `MUST_GATHER_SINCE` and `MUST_GATHER_SINCE_TIME` are set, `MUST_GATHER_SINCE_TIME` takes precedence. When neither is set, all available logs are collected.
+
 ### Gathered CRs detailed
 
 Custom Resource | Description, identification field | Selection process for NS | Selection process for Plan | Selection process for VM

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -1,0 +1,21 @@
+# Common functions for Forklift must-gather collection scripts.
+
+# Builds log_collection_args from MUST_GATHER_SINCE / MUST_GATHER_SINCE_TIME env vars.
+# When both are set, MUST_GATHER_SINCE_TIME takes precedence.
+# Usage:
+#   source common.sh
+#   get_log_collection_args
+#   /usr/bin/oc logs ${log_collection_args} --namespace ${ns} ${pod}
+get_log_collection_args() {
+    log_collection_args=""
+    if [ -n "${MUST_GATHER_SINCE:-}" ]; then
+        log_collection_args="--since=${MUST_GATHER_SINCE}"
+    fi
+    if [ -n "${MUST_GATHER_SINCE_TIME:-}" ]; then
+        log_collection_args="--since-time=${MUST_GATHER_SINCE_TIME}"
+    fi
+    if [ -n "${log_collection_args}" ]; then
+        echo "Log collection limited to ${log_collection_args}"
+    fi
+    export log_collection_args
+}

--- a/collection-scripts/gather_logs
+++ b/collection-scripts/gather_logs
@@ -1,5 +1,7 @@
 #!/bin/bash
 source pwait
+source common.sh
+get_log_collection_args
 max_parallelism=10
 
 # Namespaces passed in from main gather
@@ -11,9 +13,9 @@ for ns in ${namespaces[@]}; do
     object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
     mkdir -p ${object_collection_path}
     echo "[ns=${ns}][pod=${pod}] Collecting Pod logs..."
-    /usr/bin/oc logs --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
+    /usr/bin/oc logs ${log_collection_args} --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
     echo "[ns=${ns}][pod=${pod}] Collecting previous Pod logs..."
-    /usr/bin/oc logs --previous --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/previous.log" &
+    /usr/bin/oc logs ${log_collection_args} --previous --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/previous.log" &
     pwait $max_parallelism
   done
 done
@@ -25,9 +27,9 @@ for plan in $(/usr/bin/oc get plan --no-headers --all-namespaces -o go-template=
     object_collection_path="/must-gather/namespaces/${targetNs}/logs/${pod}"
     mkdir -p ${object_collection_path}
     echo "[ns=${targetNs}][pod=${pod}] Collecting Pod logs..."
-    /usr/bin/oc logs --all-containers --namespace ${targetNs} ${pod} &> "${object_collection_path}/current.log" &
+    /usr/bin/oc logs ${log_collection_args} --all-containers --namespace ${targetNs} ${pod} &> "${object_collection_path}/current.log" &
     echo "[ns=${targetNs}][pod=${pod}] Collecting previous Pod logs..."
-    /usr/bin/oc logs --previous --all-containers --namespace ${targetNs} ${pod} &> "${object_collection_path}/previous.log" &
+    /usr/bin/oc logs ${log_collection_args} --previous --all-containers --namespace ${targetNs} ${pod} &> "${object_collection_path}/previous.log" &
     pwait $max_parallelism
   done
 done
@@ -39,9 +41,9 @@ for component in cdi vm-import; do
     object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
     mkdir -p ${object_collection_path}
     echo "[ns=${ns}][pod=${pod}] Collecting Pod logs..."
-    /usr/bin/oc logs --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
+    /usr/bin/oc logs ${log_collection_args} --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
     echo "[ns=${ns}][pod=${pod}] Collecting previous Pod logs..."
-    /usr/bin/oc logs --previous --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/previous.log" &
+    /usr/bin/oc logs ${log_collection_args} --previous --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/previous.log" &
     pwait $max_parallelism
   done
 done
@@ -52,7 +54,7 @@ for nspod in $(oc get pods --no-headers --all-namespaces --selector kubevirt.io=
   object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
   mkdir -p ${object_collection_path}
   echo "[ns=${ns}][pod=${pod}] Collecting launcher Pod logs..."
-  /usr/bin/oc logs --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
+  /usr/bin/oc logs ${log_collection_args} --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
   pwait $max_parallelism
 done
 

--- a/collection-scripts/targeted_logs
+++ b/collection-scripts/targeted_logs
@@ -9,6 +9,8 @@
 
 unset KUBECONFIG
 source pwait
+source common.sh
+get_log_collection_args
 max_parallelism=10
 
 # Namespaces passed in from main gather
@@ -26,7 +28,7 @@ for ns in ${namespaces[@]}; do
     object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
     mkdir -p ${object_collection_path}
     echo "[ns=${ns}][pod=${pod}] Collecting Pod logs..."
-    /usr/bin/oc logs --all-containers --namespace ${ns} ${pod} | grep -E $targeted_query &> "${object_collection_path}/current.log" &
+    /usr/bin/oc logs ${log_collection_args} --all-containers --namespace ${ns} ${pod} | grep -E $targeted_query &> "${object_collection_path}/current.log" &
     pwait $max_parallelism
   done
 done
@@ -38,7 +40,7 @@ for component in cdi vm-import; do
     object_collection_path="/must-gather/namespaces/openshift-cnv/logs/${pod}"
     mkdir -p ${object_collection_path}
     echo "[ns=openshift-cnv][pod=${pod}] Collecting Pod logs..."
-    /usr/bin/oc logs --all-containers --namespace openshift-cnv ${pod} | grep -E $targeted_query &> "${object_collection_path}/current.log" &
+    /usr/bin/oc logs ${log_collection_args} --all-containers --namespace openshift-cnv ${pod} | grep -E $targeted_query &> "${object_collection_path}/current.log" &
     pwait $max_parallelism
   done
 done
@@ -54,7 +56,7 @@ for nsvm in ${target_vms[@]}; do
     object_collection_path="/must-gather/namespaces/${ns}/logs/${virtLauncherPod}"
     mkdir -p ${object_collection_path}
     echo "[ns=${ns}][pod=${virtLauncherPod}] Collecting virt-launcher Pod logs..."
-    /usr/bin/oc logs --all-containers --namespace ${ns} ${virtLauncherPod} &> "${object_collection_path}/current.log" &
+    /usr/bin/oc logs ${log_collection_args} --all-containers --namespace ${ns} ${virtLauncherPod} &> "${object_collection_path}/current.log" &
     pwait $max_parallelism
   fi
 
@@ -68,7 +70,7 @@ for nsvm in ${target_vms[@]}; do
       object_collection_path="/must-gather/namespaces/${ns}/logs/${virtV2VPod}"
       mkdir -p ${object_collection_path}
       echo "[ns=${ns}][pod=${virtV2VPod}] Collecting virt-v2v Pod logs..."
-      /usr/bin/oc logs --all-containers --namespace ${ns} ${virtV2VPod} &> "${object_collection_path}/current.log" &
+      /usr/bin/oc logs ${log_collection_args} --all-containers --namespace ${ns} ${virtV2VPod} &> "${object_collection_path}/current.log" &
       pwait $max_parallelism
     fi
 
@@ -79,7 +81,7 @@ for nsvm in ${target_vms[@]}; do
       object_collection_path="/must-gather/namespaces/${ns}/logs/${populatorPod}"
       mkdir -p ${object_collection_path}
       echo "[ns=${ns}][pod=${populatorPod}] Collecting Populator Pod logs..."
-      /usr/bin/oc logs --all-containers --namespace ${ns} ${populatorPod} &> "${object_collection_path}/current.log" &
+      /usr/bin/oc logs ${log_collection_args} --all-containers --namespace ${ns} ${populatorPod} &> "${object_collection_path}/current.log" &
       pwait $max_parallelism
     fi
   done
@@ -97,7 +99,7 @@ if [[ -z "${target_vms}" && ! -z "${target_migrations}" ]]; then
         object_collection_path="/must-gather/namespaces/${target_ns}/logs/${pod}"
         mkdir -p ${object_collection_path}
         echo "[ns=${target_ns}][pod=${pod}] Collecting migration Pod logs (no VM)..."
-        /usr/bin/oc logs --all-containers --namespace ${target_ns} ${pod} &> "${object_collection_path}/current.log" &
+        /usr/bin/oc logs ${log_collection_args} --all-containers --namespace ${target_ns} ${pod} &> "${object_collection_path}/current.log" &
         pwait $max_parallelism
       done
     done
@@ -115,7 +117,7 @@ for nsdv in ${target_dvs[@]}; do
     object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
     mkdir -p ${object_collection_path}
     echo "[ns=${ns}][pod=${pod}] Collecting CDI Importer Pod logs..."
-    /usr/bin/oc logs --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
+    /usr/bin/oc logs ${log_collection_args} --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
     pwait $max_parallelism
   fi
 done
@@ -138,7 +140,7 @@ for nspvc in ${target_pvcs[@]}; do
       object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
       mkdir -p ${object_collection_path}
       echo "[ns=${ns}][pod=${pod}] Collecting CDI Importer Pod logs..."
-      /usr/bin/oc logs --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
+      /usr/bin/oc logs ${log_collection_args} --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
       pwait $max_parallelism
     done
   fi
@@ -150,7 +152,7 @@ for nsjobpod in ${target_job_pods[@]}; do
   object_collection_path="/must-gather/namespaces/${ns}/logs/${job_pod}"
   mkdir -p ${object_collection_path}
   echo "[ns=${ns}][job=${job_pod}] Collecting migration hook job's pod logs..."
-  /usr/bin/oc logs --namespace ${ns} ${job_pod} &> "${object_collection_path}/current.log" &
+  /usr/bin/oc logs ${log_collection_args} --namespace ${ns} ${job_pod} &> "${object_collection_path}/current.log" &
   pwait $max_parallelism
 done
 


### PR DESCRIPTION
Issue: Full must-gather collects entire pod logs which can be very large for long-running pods like forklift-controller. There is no way to limit log collection by time, resulting in unnecessary data and slower collection.

Fix: Add support for MUST_GATHER_SINCE (duration, e.g. 2h) and MUST_GATHER_SINCE_TIME (RFC 3339 timestamp) environment variables, following the same convention as CNV must-gather. A new common.sh provides get_log_collection_args() which builds --since or --since-time flags for oc logs. Both gather_logs and targeted_logs source common.sh and apply the flags to all oc logs commands. When neither variable is set, behavior is unchanged.

Resolves: MTV-5113

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added time-window-based log collection with environment variables for relative duration and RFC 3339 timestamp filtering.
  * Updated must-gather scripts to support selective log collection based on specified time windows.

* **Documentation**
  * Added usage examples and precedence rules for time-window log filtering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->