### PR TITLE
chore(version): bump z-stream version to 2.10.8

### DIFF
--- a/build/release.conf
+++ b/build/release.conf
@@ -1,5 +1,5 @@
 # Global version specifying version for every component and for bundle, format "x.y.z"
-VERSION=2.10.7
+VERSION=2.10.8
 
 # Release version, format "vX.Y"
 RELEASE=v2.10


### PR DESCRIPTION
Automated z-stream version bump.

Updates version from `2.10.7` → `2.10.8` in `build/release.conf`.