### PR TITLE
chore(release): code freeze for release-2.12

### DIFF
--- a/.tekton/forklift-must-gather-2-12-pull-request.yaml
+++ b/.tekton/forklift-must-gather-2-12-pull-request.yaml
@@ -5,15 +5,15 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/kubev2v/forklift-must-gather?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: 'false'
+    pipelinesascode.tekton.dev/cancel-in-progress: 'true'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-2.12"
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: forklift-operator-dev-preview
-    appstudio.openshift.io/component: forklift-must-gather-dev-preview
+    appstudio.openshift.io/application: forklift-operator-2-12
+    appstudio.openshift.io/component: forklift-must-gather-2-12
     pipelines.appstudio.openshift.io/type: build
-  name: forklift-must-gather-dev-preview-on-push
+  name: forklift-must-gather-2-12-on-pull-request
   namespace: rh-mtv-1-tenant
 spec:
   params:
@@ -22,7 +22,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/forklift-must-gather-dev-preview:{{revision}}
+    value: quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-2-12/forklift-must-gather-2-12:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: dockerfile
     value: build/Dockerfile-downstream
   - name: path-context
@@ -584,7 +586,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-forklift-must-gather-dev-preview
+    serviceAccountName: build-pipeline-forklift-must-gather-2-12
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/forklift-must-gather-2-12-push.yaml
+++ b/.tekton/forklift-must-gather-2-12-push.yaml
@@ -5,15 +5,15 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/kubev2v/forklift-must-gather?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: 'true'
+    pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-2.12"
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: forklift-operator-dev-preview
-    appstudio.openshift.io/component: forklift-must-gather-dev-preview
+    appstudio.openshift.io/application: forklift-operator-2-12
+    appstudio.openshift.io/component: forklift-must-gather-2-12
     pipelines.appstudio.openshift.io/type: build
-  name: forklift-must-gather-dev-preview-on-pull-request
+  name: forklift-must-gather-2-12-on-push
   namespace: rh-mtv-1-tenant
 spec:
   params:
@@ -22,9 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-dev-preview/forklift-must-gather-dev-preview:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/rh-mtv-1-tenant/forklift-operator-2-12/forklift-must-gather-2-12:{{revision}}
   - name: dockerfile
     value: build/Dockerfile-downstream
   - name: path-context
@@ -586,7 +584,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-forklift-must-gather-dev-preview
+    serviceAccountName: build-pipeline-forklift-must-gather-2-12
   workspaces:
   - name: git-auth
     secret:

--- a/build/release.conf
+++ b/build/release.conf
@@ -8,10 +8,10 @@ RELEASE=v2.12
 CPE=2.12
 
 # Operator channel where the version will be deployed, e.g. dev-preview, release-v2.9 ...
-CHANNEL=dev-preview
+CHANNEL=release-v2.12
 
 # Default operator channel for other operators to pull from, if they depend on MTV
 DEFAULT_CHANNEL=release-v2.12
 
 # Registry where all components should be released to, for dev-preview -> mtv-candidate, for release-X.Y -> migration-toolkit-virtualization
-REGISTRY=mtv-candidate
+REGISTRY=migration-toolkit-virtualization


### PR DESCRIPTION
Automated branching for `release-2.12`.

- Sets `build/release.conf` for version `2.12.0`
- Updates `.tekton/` pipeline files
