### PR TITLE
fix: use label selector for virt-launcher pod lookup in targeted must-gather

### DIFF
--- a/collection-scripts/targeted_logs
+++ b/collection-scripts/targeted_logs
@@ -48,7 +48,7 @@ done
 # Collect virt-launcher and virt-v2v pod logs for migrated VMs (from VM's target namespace)
 for nsvm in ${target_vms[@]}; do
   IFS="," read ns vm vmid <<< $nsvm
-  virtLauncherPod=$(oc get pods --no-headers -n $ns --selector kubevirt.io=virt-launcher -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | grep $vm | head -1)
+  virtLauncherPod=$(oc get pods --no-headers -n $ns --selector kubevirt.io=virt-launcher,vm.kubevirt.io/name=$vm -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | head -1)
 
   if [[ -z $virtLauncherPod ]]; then
     echo "Virt-launcher Pod for $nsvm doesn't exist, skipping."


### PR DESCRIPTION
Replace grep-based virt-launcher pod lookup with a label selector (vm.kubevirt.io/name=$vm). KubeVirt truncates VM names in pod GenerateName, causing grep to match incorrectly or fail for long VM names.

Resolves: MTV-5596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized pod selection logic for improved efficiency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/forklift-must-gather/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->